### PR TITLE
Change api to export factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Webpack in a Sandbox.
 **Usage:**
 
 ```typescript
-import WebpackSandbox = require('webpack-sandboxed')
+import webpackSandboxed = require('webpack-sandboxed')
 
 const options = {
   config: { /* webpack configuration */ },
   packages: [ /* names of modules to load in the sandbox */ ],
   includes: [ /* local file paths to load in the sandbox */ ]
 }
-const sandbox = await WebpackSandbox.createInstance(options)
+const sandbox = await webpackSandboxed(options)
 const [bundle, stats] = sandbox.run("exports = {foo: 'bar'};")
 ```
 

--- a/example/main.ts
+++ b/example/main.ts
@@ -2,7 +2,7 @@ import fs = require('fs');
 import path = require('path');
 import webpack = require('webpack');
 import ExtractTextPlugin = require('extract-text-webpack-plugin');
-import WebpackSandbox from '../lib';
+import webpackSandboxed from '../lib';
 
 // Script source to compile with webpack.
 const source = `
@@ -56,7 +56,7 @@ async function main() {
     new webpack.optimize.UglifyJsPlugin()
   ];
 
-  const webpackSandbox = await WebpackSandbox.createInstance({
+  const webpackSandbox = await webpackSandboxed({
     config: {
       target: 'web',
       module: {
@@ -85,7 +85,7 @@ async function main() {
         ]
       },
       externals: {
-        react: 'React',
+        'react': 'React',
         'react-dom': 'ReactDOM'
       },
       plugins: [new ExtractTextPlugin('[name].[contenthash].css'), ...productionPlugins]

--- a/lib/WebpackRunner.ts
+++ b/lib/WebpackRunner.ts
@@ -2,8 +2,6 @@ import path = require('path');
 import webpack = require('webpack');
 import logger from './logger';
 import MemoryFS = require('memory-fs');
-import createMemoryFS from './memory-fs';
-import * as utils from './utils';
 
 export type WebpackBundle = { [key: string]: string };
 export type Options = {
@@ -36,7 +34,6 @@ interface WebpackCompiler extends webpack.Compiler {
 }
 
 const log = logger('webpack');
-const nodeModulesPath = utils.findNodeModulesPath();
 
 export default class WebpackRunner {
   private readonly memfs: MemoryFS;
@@ -45,49 +42,6 @@ export default class WebpackRunner {
   constructor(memfs: MemoryFS, config: WebpackBaseConfiguration) {
     this.memfs = memfs;
     this.config = config;
-  }
-
-  public static async createInstance(options: Options = {}): Promise<WebpackRunner> {
-    const packages = options.packages || [];
-    const includes = options.includes || [];
-    const config: webpack.Configuration = options.config || {};
-
-    // Create webpack configuration.
-    // The root directory must match the real installation directory so that tools
-    // like Babel can resolve other modules. The node module system actually
-    // operates on the real file system and not on memory-fs.
-    const root = options.basedir || path.dirname(nodeModulesPath);
-    const entry = path.join(root, 'entry.js');
-    const output = path.join(root, 'bundle/[name].[chunkhash].js');
-    const includesPath = path.join(root, 'includes');
-
-    const baseConfig: WebpackBaseConfiguration = {
-      context: path.dirname(entry),
-      entry: `./${path.basename(entry)}`,
-      output: {
-        path: path.dirname(output),
-        filename: path.basename(output)
-      },
-      resolve: {
-        modules: [path.resolve('node_modules'), path.join(root, 'node_modules'), includesPath]
-      },
-      resolveLoader: {
-        modules: [path.resolve('node_modules'), path.join(root, 'node_modules')]
-      }
-    };
-    const webpackConfig = utils.deepAssign(config, baseConfig) as WebpackBaseConfiguration;
-
-    // Webpack buildins like global, amd-define etc. are required.
-    const webpackPath = require.resolve('webpack') && path.join(nodeModulesPath, 'webpack');
-    const webpackBuildinPath = path.join(webpackPath, 'buildin');
-    packages.push(webpackBuildinPath);
-    // This webpack dependency includes node APIs required by other modules, e.g. loaders.
-    if (require.resolve('node-libs-browser')) packages.push('node-libs-browser');
-
-    const memfs = await createMemoryFS({ packages, includes, includesPath, root });
-    memfs.mkdirpSync(path.dirname(output));
-
-    return new WebpackRunner(memfs, webpackConfig);
   }
 
   private runAsync(source: string, onComplete: OnComplete): void {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,48 @@
-export { default as default } from './WebpackRunner';
+import path = require('path');
+import createMemoryFS from './memory-fs';
+import { deepAssign, findNodeModulesPath } from './utils';
+import WebpackRunner, { Options, WebpackBaseConfiguration } from './WebpackRunner';
+
+export default async function createInstance(options: Options = {}): Promise<WebpackRunner> {
+  const packages = options.packages || [];
+  const includes = options.includes || [];
+  const config = options.config || {};
+  const nodeModulesPath = findNodeModulesPath();
+
+  // Create webpack configuration.
+  // The root directory must match the real installation directory so that tools
+  // like Babel can resolve other modules. The node module system actually
+  // operates on the real file system and not on memory-fs.
+  const root = options.basedir || path.dirname(nodeModulesPath);
+  const entry = path.join(root, 'entry.js');
+  const output = path.join(root, 'bundle/[name].[chunkhash].js');
+  const includesPath = path.join(root, 'includes');
+
+  const baseConfig: WebpackBaseConfiguration = {
+    context: path.dirname(entry),
+    entry: `./${path.basename(entry)}`,
+    output: {
+      path: path.dirname(output),
+      filename: path.basename(output)
+    },
+    resolve: {
+      modules: [path.resolve('node_modules'), path.join(root, 'node_modules'), includesPath]
+    },
+    resolveLoader: {
+      modules: [path.resolve('node_modules'), path.join(root, 'node_modules')]
+    }
+  };
+  const webpackConfig = deepAssign(config, baseConfig) as WebpackBaseConfiguration;
+
+  // Webpack buildins like global, amd-define etc. are required.
+  const webpackPath = require.resolve('webpack') && path.join(nodeModulesPath, 'webpack');
+  const webpackBuildinPath = path.join(webpackPath, 'buildin');
+  packages.push(webpackBuildinPath);
+  // This webpack dependency includes node APIs required by other modules, e.g. loaders.
+  if (require.resolve('node-libs-browser')) packages.push('node-libs-browser');
+
+  const memfs = await createMemoryFS({ packages, includes, includesPath, root });
+  memfs.mkdirpSync(path.dirname(output));
+
+  return new WebpackRunner(memfs, webpackConfig);
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "webpack": "^2.6.1"
   },
   "dependencies": {
+    "@types/memory-fs": "0.3.0",
     "memory-fs": "0.4.1",
     "resolve": "1.3.3"
   },
@@ -36,7 +37,6 @@
     "@types/debug": "0.0.29",
     "@types/extract-text-webpack-plugin": "2.1.0",
     "@types/jest": "19.2.4",
-    "@types/memory-fs": "0.3.0",
     "@types/resolve": "0.0.4",
     "@types/webpack": "2.2.15",
     "babel-core": "6.24.1",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webpack should generate a JavaScript bundle 1`] = `
+exports[`webpack-sandboxed should generate a JavaScript bundle 1`] = `
 "/******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,10 @@
 /// <reference types="jest" />
 
-import WebpackRunner from '../lib/WebpackRunner';
+import webpackSandboxed from '../lib';
 
-describe('webpack', () => {
+describe('webpack-sandboxed', () => {
   it('should generate a JavaScript bundle', async () => {
-    const runner = await WebpackRunner.createInstance();
+    const runner = await webpackSandboxed();
     const [bundle, stats] = await runner.run('var x = 41 + 1;');
 
     expect(Object.keys(bundle).length).toBe(1);


### PR DESCRIPTION
BREAKING: index.ts now directly exports a factory function.

Dependencies now include `@types/memory-fs`.